### PR TITLE
manifest.json, README.md, lock.py ajusted!

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Copy the files from the directories into your homeassistant directory.
 ```
 custom_components/kevo/__init__.py
 custom_components/kevo/lock.py
+custom_components/kevo/manifest.json
 ```
 
 congifuration.yaml file entry:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# homeassistant custom components - kevo
+# Hass.io custom component - kevo
 
-## Requirements
+## Needed python module
 
-Make sure 'pykevocontrol' requirements installing properly in '/deps' folder. Can be found here: https://github.com/Bahnburner/pykevoplus/tree/master/pykevoplus
+The ```pykevocontrol``` module is automatically installed when first used of this custom component on Hass.io.
 
 ## Kevo lock integration
 

--- a/custom_components/kevo/lock.py
+++ b/custom_components/kevo/lock.py
@@ -7,9 +7,6 @@ from homeassistant.components.lock import LockDevice, PLATFORM_SCHEMA
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, STATE_LOCKED, STATE_UNLOCKED
 import homeassistant.helpers.config_validation as cv
 
-# Home Assistant depends on 3rd party packages for API specific code.
-REQUIREMENTS = ['pykevocontrol==2.0.0']
-
 _LOGGER = logging.getLogger(__name__)
 
 # Validation of the user's configuration

--- a/custom_components/kevo/manifest.json
+++ b/custom_components/kevo/manifest.json
@@ -3,6 +3,6 @@
   "name": "Kevo Lock",
   "documentation": "https://github.com/plmilord/Hass.io-custom-component-kevo/blob/master/README.md",
   "dependencies": [],
-  "codeowners": ["gaggle331/plmilord"],
+  "codeowners": ["bahnburner/gaggle331/plmilord"],
   "requirements": ["pykevocontrol==2.0.0"]
 }

--- a/custom_components/kevo/manifest.json
+++ b/custom_components/kevo/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "kevo",
+  "name": "Kevo Lock",
+  "documentation": "https://github.com/plmilord/Hass.io-custom-component-kevo/blob/master/README.md",
+  "dependencies": [],
+  "codeowners": ["gaggle331/plmilord"],
+  "requirements": ["pykevocontrol==2.0.0"]
+}


### PR DESCRIPTION
- Added 'manifest.json` to allow the installation of requirements on Hass.io> 0.92
- Removing the REQUIREMENTS constant in `lock.py`
- `README.md` adjusted