### PR TITLE
Specify lock ids rather than pull from kevo account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hass.io custom component - Kevo
 
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+
 Update: As of 9 Sep 2019, pykevoplus:Kevo.GetLocks() can no longer pull lock ids due to CAPTCHA changes. This fork does NOT pull lock ids, but rather requires you to specify one specific lock via the lock_id attribute in order to connect a Kevo lock to Home Assistant.
 
 ## What you need

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hass.io custom component - Kevo
 
+Update: As of 9 Sep 2019, pykevoplus:Kevo.GetLocks() can no longer pull lock ids due to CAPTCHA changes. This fork does NOT pull lock ids, but rather requires you to specify one specific lock via the lock_id attribute in order to connect a Kevo lock to Home Assistant.
+
 ## What you need
 
 - A Kevo smart lock
@@ -27,7 +29,9 @@ lock:
   - platform: Kevo
     email: KEVO_ACCOUNT_EMAIL         # Your Kevo account Email
     password: KEVO_ACCOUNT_PASSWORD   # Your Kevo account Password
+    lock_id: KEVO_LOCK_ID             # Your Kevo lock id (obtained manually from kevo website*)
 ```
+\* instructions for obtaining lock id can be found at: https://github.com/davidlang42/pykevoplus3
      
 ## TODOs
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ The ```pykevocontrol``` module is automatically installed when first used of thi
 
 ## Kevo custom component setup
 
-Copy these project files into your Home Assistant ```/config``` directory.
+This component can be added by adding the GitHub repository URL into the HACS system.
+
+Alternatively, you can copy these project files into your Home Assistant ```/config``` directory:
 
 ```
 custom_components/Kevo/__init__.py
@@ -24,7 +26,7 @@ custom_components/Kevo/lock.py
 custom_components/Kevo/manifest.json
 ```
 
-congifuration.yaml file entry:
+Once installed, add this to your congifuration.yaml file:
 ```
 # Locks controls
 lock:
@@ -32,10 +34,13 @@ lock:
     email: KEVO_ACCOUNT_EMAIL         # Your Kevo account Email
     password: KEVO_ACCOUNT_PASSWORD   # Your Kevo account Password
     lock_id: KEVO_LOCK_ID             # Your Kevo lock id (obtained manually from kevo website*)
+    max_retries: 3                    # Optionally set how many times it should try to initalise the lock
+    retry_delay: 2                    # Optionally set the delay (in seconds) between each retry
 ```
-\* instructions for obtaining lock id can be found at: https://github.com/davidlang42/pykevoplus3
+\* You can get the lock IDs manually by logging into mykevo.com, click Details for the lock, click Settings, the lock ID is on the right.
      
 ## TODOs
 
-- 
+- handle multiple kevo locks with the same or different account credentials
+- set friendly name for devices
 

--- a/custom_components/Kevo/lock.py
+++ b/custom_components/Kevo/lock.py
@@ -25,6 +25,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     # present.
     email = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
+    lock_id = config.get(CONF_LOCK_ID)
 
     # Setup connection with devices/cloud (broken as of 9 Sep 2019 due to CAPTCHA changes)
     # kevos = Kevo.GetLocks(email, password)

--- a/custom_components/Kevo/lock.py
+++ b/custom_components/Kevo/lock.py
@@ -8,6 +8,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, STATE_LOCKED, STATE_U
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
+CONF_LOCK_ID = "lock_id"
 
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/custom_components/Kevo/lock.py
+++ b/custom_components/Kevo/lock.py
@@ -1,5 +1,5 @@
 import logging
-
+import time
 import voluptuous as vol
 
 # Import the device class from the component that you want to support
@@ -9,12 +9,16 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 CONF_LOCK_ID = "lock_id"
+CONF_MAX_RETRIES = "max_retries"
+CONF_RETRY_DELAY = "retry_delay"
 
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_EMAIL): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_LOCK_ID): cv.string,
+    vol.Optional(CONF_MAX_RETRIES, default=3): cv.positive_int,
+    vol.Optional(CONF_RETRY_DELAY, default=2): cv.positive_int
 })
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -26,13 +30,25 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     email = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
     lock_id = config.get(CONF_LOCK_ID)
+    max_retries = config.get(CONF_MAX_RETRIES)
+    retry_delay = config.get(CONF_RETRY_DELAY)
 
     # Setup connection with devices/cloud (broken as of 9 Sep 2019 due to CAPTCHA changes)
     # kevos = Kevo.GetLocks(email, password)
     # add_devices(KevoDevice(kevo) for kevo in kevos)
 
     # Setup manual connection with specified device
-    kevo = KevoLock.FromLockID(lock_id, email, password)
+    for attempt in range(max_retries):
+        try:
+            kevo = KevoLock.FromLockID(lock_id, email, password)
+        except:
+            if attempt == max_retries - 1:
+                raise
+            else:
+                time.sleep(retry_delay)
+        else:
+            break
+    
     add_devices([KevoDevice(kevo)])
 
 class KevoDevice(LockDevice):

--- a/custom_components/Kevo/lock.py
+++ b/custom_components/Kevo/lock.py
@@ -13,22 +13,25 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_EMAIL): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_LOCK_ID): cv.string,
 })
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the Kevo platform."""
-    from pykevoplus import Kevo
+    from pykevoplus import KevoLock
 
     # Assign configuration variables. The configuration check takes care they are
     # present.
     email = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
 
-    # Setup connection with devices/cloud
-    kevos = Kevo.GetLocks(email, password)
+    # Setup connection with devices/cloud (broken as of 9 Sep 2019 due to CAPTCHA changes)
+    # kevos = Kevo.GetLocks(email, password)
+    # add_devices(KevoDevice(kevo) for kevo in kevos)
 
-    # Add devices
-    add_devices(KevoDevice(kevo) for kevo in kevos)
+    # Setup manual connection with specified device
+    kevo = KevoLock.FromLockID(lock_id, email, password)
+    add_devices([KevoDevice(kevo)])
 
 class KevoDevice(LockDevice):
     """Representation of a Kevo Lock."""

--- a/custom_components/Kevo/manifest.json
+++ b/custom_components/Kevo/manifest.json
@@ -3,6 +3,6 @@
   "name": "Kevo Lock",
   "documentation": "https://github.com/davidlang42/home-assistant-kevo/blob/master/README.md",
   "dependencies": [],
-  "codeowners": ["bahnburner/gaggle331/plmilord/davidlang42"],
+  "codeowners": ["bahnburner/gaggle331/plmilord", "davidlang42"],
   "requirements": ["pykevocontrol==2.0.0"]
 }

--- a/custom_components/Kevo/manifest.json
+++ b/custom_components/Kevo/manifest.json
@@ -1,8 +1,8 @@
 {
-  "domain": "Kevo",
+  "domain": "kevo",
   "name": "Kevo Lock",
-  "documentation": "https://github.com/plmilord/Hass.io-custom-component-Kevo/blob/master/README.md",
+  "documentation": "https://github.com/davidlang42/home-assistant-kevo/blob/master/README.md",
   "dependencies": [],
-  "codeowners": ["bahnburner/gaggle331/plmilord"],
+  "codeowners": ["bahnburner/gaggle331/plmilord/davidlang42"],
   "requirements": ["pykevocontrol==2.0.0"]
 }

--- a/custom_components/Kevo/manifest.json
+++ b/custom_components/Kevo/manifest.json
@@ -1,5 +1,5 @@
 {
-  "domain": "kevo",
+  "domain": "Kevo",
   "name": "Kevo Lock",
   "documentation": "https://github.com/davidlang42/home-assistant-kevo/blob/master/README.md",
   "dependencies": [],

--- a/custom_components/Kevo/manifest.json
+++ b/custom_components/Kevo/manifest.json
@@ -3,6 +3,6 @@
   "name": "Kevo Lock",
   "documentation": "https://github.com/davidlang42/home-assistant-kevo/blob/master/README.md",
   "dependencies": [],
-  "codeowners": ["bahnburner/gaggle331/plmilord", "davidlang42"],
+  "codeowners": ["bahnburner","gaggle331","plmilord","davidlang42"],
   "requirements": ["pykevocontrol==2.0.0"]
 }


### PR DESCRIPTION
The CAPTCHA changes of Sep 2019 broke the ability to use this component due to the parsing of locks from your kevo account, however if you specify the lock_id manually then it still works.